### PR TITLE
add Azure Pipelines agent image

### DIFF
--- a/e2e/images/azure-pipelines/agent/Dockerfile
+++ b/e2e/images/azure-pipelines/agent/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:18.04
+
+# To make it easier for build and release pipelines to run apt-get,
+# configure apt to not require confirmation (assume the -y argument by default)
+ENV DEBIAN_FRONTEND=noninteractive
+RUN echo "APT::Get::Assume-Yes \"true\";" > /etc/apt/apt.conf.d/90assumeyes
+
+RUN apt-get update \
+&& apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        jq \
+        git \
+        iputils-ping \
+        libcurl4 \
+        libicu60 \
+        libunwind8 \
+        netcat \
+        libssl1.0
+
+WORKDIR /azp
+
+COPY ./start.sh .
+RUN chmod +x start.sh
+
+CMD ["./start.sh"]

--- a/e2e/images/azure-pipelines/agent/start.sh
+++ b/e2e/images/azure-pipelines/agent/start.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+set -e
+
+if [ -z "$AZP_URL" ]; then
+  echo 1>&2 "error: missing AZP_URL environment variable"
+  exit 1
+fi
+
+if [ -z "$AZP_TOKEN_FILE" ]; then
+  if [ -z "$AZP_TOKEN" ]; then
+    echo 1>&2 "error: missing AZP_TOKEN environment variable"
+    exit 1
+  fi
+
+  AZP_TOKEN_FILE=/azp/.token
+  echo -n $AZP_TOKEN > "$AZP_TOKEN_FILE"
+fi
+
+unset AZP_TOKEN
+
+if [ -n "$AZP_WORK" ]; then
+  mkdir -p "$AZP_WORK"
+fi
+
+rm -rf /azp/agent
+mkdir /azp/agent
+cd /azp/agent
+
+export AGENT_ALLOW_RUNASROOT="1"
+
+cleanup() {
+  if [ -e config.sh ]; then
+    print_header "Cleanup. Removing Azure Pipelines agent..."
+
+    ./config.sh remove --unattended \
+      --auth PAT \
+      --token $(cat "$AZP_TOKEN_FILE")
+  fi
+}
+
+print_header() {
+  lightcyan='\033[1;36m'
+  nocolor='\033[0m'
+  echo -e "${lightcyan}$1${nocolor}"
+}
+
+# Let the agent ignore the token env variables
+export VSO_AGENT_IGNORE=AZP_TOKEN,AZP_TOKEN_FILE
+
+print_header "1. Determining matching Azure Pipelines agent..."
+
+AZP_AGENT_RESPONSE=$(curl -LsS \
+  -u user:$(cat "$AZP_TOKEN_FILE") \
+  -H 'Accept:application/json;api-version=3.0-preview' \
+  "$AZP_URL/_apis/distributedtask/packages/agent?platform=linux-x64")
+
+if echo "$AZP_AGENT_RESPONSE" | jq . >/dev/null 2>&1; then
+  AZP_AGENTPACKAGE_URL=$(echo "$AZP_AGENT_RESPONSE" \
+    | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+fi
+
+if [ -z "$AZP_AGENTPACKAGE_URL" -o "$AZP_AGENTPACKAGE_URL" == "null" ]; then
+  echo 1>&2 "error: could not determine a matching Azure Pipelines agent - check that account '$AZP_URL' is correct and the token is valid for that account"
+  exit 1
+fi
+
+print_header "2. Downloading and installing Azure Pipelines agent..."
+
+curl -LsS $AZP_AGENTPACKAGE_URL | tar -xz & wait $!
+
+source ./env.sh
+
+print_header "3. Configuring Azure Pipelines agent..."
+
+./config.sh --unattended \
+  --agent "${AZP_AGENT_NAME:-$(hostname)}" \
+  --url "$AZP_URL" \
+  --auth PAT \
+  --token $(cat "$AZP_TOKEN_FILE") \
+  --pool "${AZP_POOL:-Default}" \
+  --work "${AZP_WORK:-_work}" \
+  --replace \
+  --acceptTeeEula & wait $!
+
+print_header "4. Running Azure Pipelines agent..."
+
+trap 'cleanup; exit 130' SIGINT
+trap 'cleanup; exit 143' SIGTERM
+
+# To be aware of TERM and INT signals call run.sh
+# Running it with the --once flag at the end will shut down the agent after the build is executed
+./run.sh & wait $!


### PR DESCRIPTION
This PR adds a test image to be used in the e2e test for the Azure Pipelines scaler.

Link to the [docs](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/docker?view=azure-devops#linux)

Relates to kedacore/keda#1706
Relates to kedacore/keda#1705