### PR TITLE
chore: KEDA was accepted as CNCF Incubation project

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Repository provides all tooling for running our tests:
 - Docker images which are available on [GitHub Container Registry](https://github.com/orgs/kedacore/packages?type=source)
 - Integrations with 3rd party services, such as Azure Pipelines
 
-We are a Cloud Native Computing Foundation (CNCF) sandbox project.
+We are a Cloud Native Computing Foundation (CNCF) incubation project.
 ![CNCF Logo](https://raw.githubusercontent.com/kedacore/keda/master/images/logo-cncf.svg)


### PR DESCRIPTION
KEDA was accepted as CNCF Incubation project as per https://github.com/cncf/toc/pull/622

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Relates to https://github.com/kedacore/governance/issues/2
