### PR TITLE
Sets transaction's isolation level as default in postgresql image

### DIFF
--- a/e2e/images/postgresql/cmd/main.go
+++ b/e2e/images/postgresql/cmd/main.go
@@ -67,7 +67,7 @@ func updateTaskInstances(numberOfTaskInstancesToUpdate int) {
 	defer db.Close()
 	for i := 0; i < numberOfTaskInstancesToUpdate; i++ {
 		ctx := context.Background()
-		tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+		tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelDefault})
 		if err != nil {
 			log.Fatalf("Error creating transaction %v", err)
 		}


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

The previous transaction level produces concurrency errors in Postgres (probably because the behavior is different in Postgres than MySQL). This PR sets the isolation level as default and now all work

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)


