### PR TITLE
Updates PostgreSQL e2e image to handle concurrency in the transactions

### DIFF
--- a/e2e/images/postgresql/cmd/main.go
+++ b/e2e/images/postgresql/cmd/main.go
@@ -67,13 +67,13 @@ func updateTaskInstances(numberOfTaskInstancesToUpdate int) {
 	defer db.Close()
 	for i := 0; i < numberOfTaskInstancesToUpdate; i++ {
 		ctx := context.Background()
-		tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+		tx, err := db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelReadCommitted})
 		if err != nil {
 			log.Fatalf("Error creating transaction %v", err)
 		}
 
 		var taskInstance taskInstance
-		err = tx.QueryRowContext(ctx, "SELECT id, state FROM task_instance WHERE state = $1 LIMIT 1", queued).Scan(&taskInstance.id, &taskInstance.state)
+		err = tx.QueryRowContext(ctx, "SELECT id, state FROM task_instance WHERE state = $1 LIMIT 1 FOR UPDATE", queued).Scan(&taskInstance.id, &taskInstance.state)
 		if err != nil {
 			tx.Rollback()
 			log.Fatal(err)


### PR DESCRIPTION
Signed-off-by: jorturfer <jorge_turrado@hotmail.es>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

The previous transaction level produces concurrency errors in Postgres (probably because the behavior is different in Postgres than MySQL). This PR sets the isolation level and update the query to ensure that the same row is not selected twice

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)