### PR TITLE
Update az agent to run only one job and finish the container

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# normalize all introduced text files to LF line endings (recognized by git)
+ *           text=auto
+ # additionally declare text file types
+ *.sh        text eol=lf

--- a/e2e/images/azure-pipelines/agent/Dockerfile
+++ b/e2e/images/azure-pipelines/agent/Dockerfile
@@ -20,7 +20,11 @@ RUN apt-get update \
 
 WORKDIR /azp
 
+RUN mkdir ./patches
+COPY ./patches/AgentService.js ./patches/
 COPY ./start.sh .
+COPY ./start-once.sh .
 RUN chmod +x start.sh
+RUN chmod +x start-once.sh
 
-CMD ["./start.sh"]
+CMD ["./start-once.sh"]

--- a/e2e/images/azure-pipelines/agent/patches/AgentService.js
+++ b/e2e/images/azure-pipelines/agent/patches/AgentService.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+var childProcess = require("child_process");
+var path = require("path")
+
+var supported = ['linux', 'darwin']
+
+if (supported.indexOf(process.platform) == -1) {
+    console.log('Unsupported platform: ' + process.platform);
+    console.log('Supported platforms are: ' + supported.toString());
+    process.exit(1);
+}
+
+var stopping = false;
+var listener = null;
+
+var runService = function() {
+    var listenerExePath = path.join(__dirname, '../bin/Agent.Listener');
+    var interactive = process.argv[2] === "interactive";
+
+    if(!stopping) {
+        try {
+            if (interactive) {
+                console.log('Starting Agent listener interactively');                
+                // skip all paramters before interactive (inclusive)
+                listenerArgs = ['run'].concat(process.argv.splice(3));
+            } else {
+                console.log('Starting Agent listener with startup type: service');
+                listenerArgs = ['run', '--startuptype', 'service'].concat(process.argv.splice(2))
+            }
+
+            listener = childProcess.spawn(listenerExePath, listenerArgs, { env: process.env });
+
+            console.log('Started listener process');
+        
+            listener.stdout.on('data', (data) => {
+                process.stdout.write(data.toString('utf8'));
+            });
+
+            listener.stderr.on('data', (data) => {
+                process.stdout.write(data.toString('utf8'));
+            });
+
+            listener.on('close', (code) => {
+                console.log(`Agent listener exited with error code ${code}`);
+
+                if (code === 0) {
+                    console.log('Agent listener exit with 0 return code, stop the service, no retry needed.');
+                    stopping = true;
+                } else if (code === 1) {
+                    console.log('Agent listener exit with terminated error, stop the service, no retry needed.');
+                    stopping = true;
+                } else if (code === 2) {
+                    console.log('Agent listener exit with retryable error, re-launch agent in 5 seconds.');
+                } else if (code === 3) {
+                    console.log('Agent listener exit because of updating, re-launch agent in 5 seconds.');
+                } else {
+                    console.log('Agent listener exit with undefined return code, re-launch agent in 5 seconds.');
+                }
+                
+                if(!stopping) {
+                    setTimeout(runService, 5000);
+                }
+            });
+
+        } catch(ex) {
+            console.log(ex);
+        }
+    }
+}
+
+runService();
+console.log('Started running service');
+
+var gracefulShutdown = function(code) {
+    console.log('Shutting down agent listener');
+    stopping = true;
+    if (listener) {
+        console.log('Sending SIGINT to agent listener to stop');
+        listener.kill('SIGINT');
+
+        // TODO wait for 30 seconds and send a SIGKILL
+    }
+}
+
+process.on('SIGINT', () => {
+    gracefulShutdown(0);
+});
+
+process.on('SIGTERM', () => {
+    gracefulShutdown(0);
+});

--- a/e2e/images/azure-pipelines/agent/start-once.sh
+++ b/e2e/images/azure-pipelines/agent/start-once.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+set -e
+
+if [ -z "$AZP_URL" ]; then
+  echo 1>&2 "error: missing AZP_URL environment variable"
+  exit 1
+fi
+
+if [ -z "$AZP_TOKEN_FILE" ]; then
+  if [ -z "$AZP_TOKEN" ]; then
+    echo 1>&2 "error: missing AZP_TOKEN environment variable"
+    exit 1
+  fi
+
+  AZP_TOKEN_FILE=/azp/.token
+  echo -n $AZP_TOKEN > "$AZP_TOKEN_FILE"
+fi
+
+unset AZP_TOKEN
+
+if [ -n "$AZP_WORK" ]; then
+  mkdir -p "$AZP_WORK"
+fi
+
+rm -rf /azp/agent
+mkdir /azp/agent
+cd /azp/agent
+
+export AGENT_ALLOW_RUNASROOT="1"
+
+cleanup() {
+  if [ -e config.sh ]; then
+    retry=1
+
+    while [ $retry -lt 5 ]
+    do
+      print_header "Cleanup. Removing Azure Pipelines agent. Try $retry"
+
+      ./config.sh remove --unattended \
+        --auth PAT \
+        --token $(cat "$AZP_TOKEN_FILE")
+
+      if [ $? -eq 0 ]; then
+        retry=999
+      else
+        print_header "Cleanup failed with code $?. sleeping before retrying"
+
+        $retry=$[$retry+1]
+        sleep 30
+      fi
+    done
+  fi
+}
+
+print_header() {
+  echo -e "$1"
+}
+
+# Let the agent ignore the token env variables
+export VSO_AGENT_IGNORE=AZP_TOKEN,AZP_TOKEN_FILE
+
+print_header "1. Determining matching Azure Pipelines agent..."
+
+AZP_AGENT_RESPONSE=$(curl -LsS \
+  -u user:$(cat "$AZP_TOKEN_FILE") \
+  -H 'Accept:application/json;api-version=3.0-preview' \
+  "$AZP_URL/_apis/distributedtask/packages/agent?platform=linux-x64")
+
+if echo "$AZP_AGENT_RESPONSE" | jq . >/dev/null 2>&1; then
+  AZP_AGENTPACKAGE_URL=$(echo "$AZP_AGENT_RESPONSE" \
+    | jq -r '.value | map([.version.major,.version.minor,.version.patch,.downloadUrl]) | sort | .[length-1] | .[3]')
+fi
+
+if [ -z "$AZP_AGENTPACKAGE_URL" -o "$AZP_AGENTPACKAGE_URL" == "null" ]; then
+  echo 1>&2 "error: could not determine a matching Azure Pipelines agent - check that account '$AZP_URL' is correct and the token is valid for that account"
+  exit 1
+fi
+
+print_header "2. Downloading and installing Azure Pipelines agent..."
+
+curl -LsS $AZP_AGENTPACKAGE_URL | tar -xz & wait $!
+
+source ./env.sh
+
+trap 'cleanup; exit 130' INT
+trap 'cleanup; exit 143' TERM
+
+print_header "3. Configuring Azure Pipelines agent..."
+
+./config.sh --unattended \
+  --agent "${AZP_AGENT_NAME:-$(hostname)}" \
+  --url "$AZP_URL" \
+  --auth PAT \
+  --token $(cat "$AZP_TOKEN_FILE") \
+  --pool "${AZP_POOL:-Default}" \
+  --work "${AZP_WORK:-_work}" \
+  --replace \
+--acceptTeeEula & wait $!
+
+print_header "6. Patching listener..."
+
+cp ../patches/AgentService.js ./bin/
+
+print_header "5. Running Azure Pipelines agent..."
+
+# `exec` the node runtime so it's aware of TERM and INT signals
+# AgentService.js understands how to handle agent self-update and restart
+./externals/node/bin/node ./bin/AgentService.js interactive --once
+
+print_header "6. Removing Azure Pipelines agent..."
+
+cleanup
+
+print_header "7. Agent has been cleaned up..."

--- a/e2e/integrations/azure-pipelines/pipeline.yml
+++ b/e2e/integrations/azure-pipelines/pipeline.yml
@@ -1,7 +1,7 @@
 # Pipeline to use during our end-to-end tests for our Azure Pipelines scaler
 
-trigger:
-- main
+pr: none
+trigger: none
 
 pool: end-to-end-tests
 


### PR DESCRIPTION
I'm fixing az-pipelines using ScaledJobs intead of ScaledObject to avoid killing a pod which is executing an AzPipeline
That's why I need to update current image using [ephemeral agents](https://github.com/microsoft/azure-pipelines-ephemeral-agents). 
I know that the repo is in read-only mode, but for our use case I think that is not important at all because we only need the startup modification and not the networking features