### PR TITLE
Remove dockerhub image generation

### DIFF
--- a/e2e/images/build.sh
+++ b/e2e/images/build.sh
@@ -15,16 +15,13 @@ then
     for IMAGE_NAME in $(find * -name Dockerfile -exec dirname {} \; | tr '/' '-')
     do
         docker image push -a ghcr.io/kedacore/tests-$IMAGE_NAME
-        docker image push -a docker.io/kedacore/tests-$IMAGE_NAME
     done
 else
     for IMAGE in $(find * -name Dockerfile)
     do
         IMAGE_NAME=$(dirname $IMAGE | tr '/' '-')
         pushd $(dirname $IMAGE)
-        docker build -t docker.io/kedacore/tests-$IMAGE_NAME:$IMAGE_TAG -t docker.io/kedacore/tests-$IMAGE_NAME:latest .
-        docker tag docker.io/kedacore/tests-$IMAGE_NAME:$IMAGE_TAG ghcr.io/kedacore/tests-$IMAGE_NAME:$IMAGE_TAG
-        docker tag docker.io/kedacore/tests-$IMAGE_NAME:$IMAGE_TAG ghcr.io/kedacore/tests-$IMAGE_NAME:latest
+        docker build -t ghcr.io/kedacore/tests-$IMAGE_NAME:$IMAGE_TAG -t ghcr.io/kedacore/tests-$IMAGE_NAME:latest .
         popd
     done
 fi


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

We don't use dockerhub any more, doesn't make sense to generate e2e test images and push there

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Related https://github.com/kedacore/governance/issues/16