### PR TITLE
feat: Add dotnet eventhub e2e image

### DIFF
--- a/e2e/images/azure-eventhub-dotnet/Dockerfile
+++ b/e2e/images/azure-eventhub-dotnet/Dockerfile
@@ -1,0 +1,20 @@
+#See https://aka.ms/containerfastmode to understand how Visual Studio uses this Dockerfile to build your images for faster debugging.
+
+FROM mcr.microsoft.com/dotnet/runtime:6.0 AS base
+WORKDIR /app
+
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
+COPY ["EventHubWorker.csproj", "."]
+RUN dotnet restore "EventHubWorker.csproj"
+COPY . .
+WORKDIR "/src"
+RUN dotnet build "EventHubWorker.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "EventHubWorker.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "EventHubWorker.dll"]

--- a/e2e/images/azure-eventhub-dotnet/EventHubWorker.csproj
+++ b/e2e/images/azure-eventhub-dotnet/EventHubWorker.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.17.0" />
+	<PackageReference Include="Azure.Messaging.EventHubs.Processor" Version="5.7.2" />
+  </ItemGroup>
+
+
+</Project>

--- a/e2e/images/azure-eventhub-dotnet/Program.cs
+++ b/e2e/images/azure-eventhub-dotnet/Program.cs
@@ -1,0 +1,10 @@
+using EventHubWorker;
+
+IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices(services =>
+    {
+        services.AddHostedService<Worker>();
+    })
+    .Build();
+
+await host.RunAsync();

--- a/e2e/images/azure-eventhub-dotnet/Worker.cs
+++ b/e2e/images/azure-eventhub-dotnet/Worker.cs
@@ -1,0 +1,61 @@
+using Azure.Messaging.EventHubs;
+using Azure.Messaging.EventHubs.Processor;
+using Azure.Storage.Blobs;
+using System.Diagnostics;
+using System.Text;
+
+namespace EventHubWorker
+{
+    public class Worker : BackgroundService
+    {
+        string ehubNamespaceConnectionString = Environment.GetEnvironmentVariable("EVENTHUB_CONNECTION_STRING");
+        string blobStorageConnectionString = Environment.GetEnvironmentVariable("STORAGE_CONNECTION_STRING");
+        string blobContainerName = Environment.GetEnvironmentVariable("CHECKPOINT_CONTAINER");
+        string consumerGroup = Environment.GetEnvironmentVariable("EVENTHUB_CONSUMERGROUP");
+        private EventProcessorClient _processor;
+        private readonly ILogger<Worker> _logger;
+
+        public Worker(ILogger<Worker> logger)
+        {
+            _logger = logger;
+            var storageClient = new BlobContainerClient(blobStorageConnectionString, blobContainerName);
+            _processor = new EventProcessorClient(storageClient, consumerGroup, ehubNamespaceConnectionString);
+            _processor.ProcessEventAsync += ProcessEventHandler;
+            _processor.ProcessErrorAsync += ProcessErrorHandler;
+        }
+
+        public override Task StartAsync(CancellationToken cancellationToken)
+        {
+            _processor.StartProcessingAsync();
+            return base.StartAsync(cancellationToken);
+        }
+
+        public override Task StopAsync(CancellationToken cancellationToken)
+        {
+            _processor.StopProcessingAsync();
+            return base.StopAsync(cancellationToken);
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken) {}
+
+        async Task ProcessEventHandler(ProcessEventArgs eventArgs)
+        {
+            // Write the body of the event to the console window
+            Console.WriteLine("\tReceived event: {0}", Encoding.UTF8.GetString(eventArgs.Data.Body.ToArray()));
+
+            // Update checkpoint in the blob storage so that the app receives only new events the next time it's run
+            await eventArgs.UpdateCheckpointAsync(eventArgs.CancellationToken);
+        }
+
+        Task ProcessErrorHandler(ProcessErrorEventArgs eventArgs)
+        {
+            // Write details about the error to the console window
+            Console.WriteLine($"\tPartition '{eventArgs.PartitionId}': an unhandled exception was encountered. This was not expected to happen.");
+            Console.WriteLine(eventArgs.Exception.Message);
+            return Task.CompletedTask;
+        }
+    }
+}
+
+
+


### PR DESCRIPTION
Signed-off-by: Jorge Turrado <jorge_turrado@hotmail.es>

I know that we try to use golang for e2e test images, but we need dotnet image to check `checkpointStrategy: blobMetadata` 

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
