### PR TITLE
chore: add label to link docker images with test-tools repo

### DIFF
--- a/e2e/images/build.sh
+++ b/e2e/images/build.sh
@@ -21,7 +21,7 @@ else
     do
         IMAGE_NAME=$(dirname $IMAGE | tr '/' '-')
         pushd $(dirname $IMAGE)
-        docker build --label "org.opencontainers.image.source https://github.com/kedacore/test-tools" -t ghcr.io/kedacore/tests-$IMAGE_NAME:$IMAGE_TAG -t ghcr.io/kedacore/tests-$IMAGE_NAME:latest .
+        docker build --label "org.opencontainers.image.source=https://github.com/kedacore/test-tools" -t ghcr.io/kedacore/tests-$IMAGE_NAME:$IMAGE_TAG -t ghcr.io/kedacore/tests-$IMAGE_NAME:latest .
         popd
     done
 fi

--- a/e2e/images/build.sh
+++ b/e2e/images/build.sh
@@ -21,7 +21,7 @@ else
     do
         IMAGE_NAME=$(dirname $IMAGE | tr '/' '-')
         pushd $(dirname $IMAGE)
-        docker build -t ghcr.io/kedacore/tests-$IMAGE_NAME:$IMAGE_TAG -t ghcr.io/kedacore/tests-$IMAGE_NAME:latest .
+        docker build --label "org.opencontainers.image.source https://github.com/kedacore/test-tools" -t ghcr.io/kedacore/tests-$IMAGE_NAME:$IMAGE_TAG -t ghcr.io/kedacore/tests-$IMAGE_NAME:latest .
         popd
     done
 fi


### PR DESCRIPTION
Adding this label to the images, they will be automatically linked with this repository.

This means that the repo will appear here: 
![image](https://user-images.githubusercontent.com/36899226/229177104-87e6c19f-8ccd-44b7-82a8-9a0c1d6ab102.png)

And all the test-tool images will be listed here: 
![image](https://user-images.githubusercontent.com/36899226/229177187-1f9b1584-258d-4363-be1c-02d3144e820f.png)


### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

