### PR TITLE
chore: use log instead fmt for external scaler

### DIFF
--- a/e2e/images/external-scaler/main.go
+++ b/e2e/images/external-scaler/main.go
@@ -19,7 +19,7 @@ func setValue(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	number := vars["number"]
 	ExternalScalerValue, _ = strconv.ParseInt(number, 10, 64)
-	fmt.Printf("new value: %d", ExternalScalerValue)
+	log.Printf("new value: %d\n", ExternalScalerValue)
 }
 
 func RunManagementApi() {


### PR DESCRIPTION
### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Fixes #
