### PR TITLE
Add ibmmq e2e image

### DIFF
--- a/e2e/images/ibmmq/Dockerfile
+++ b/e2e/images/ibmmq/Dockerfile
@@ -1,0 +1,33 @@
+FROM golang:1.22.2 as build-env
+
+# Create MQ installation
+RUN mkdir -p /opt/mqm \
+    && chmod a+rx /opt/mqm
+# Location of the downloadable MQ client package \
+ENV RDURL="https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist" \
+    RDTAR="IBM-MQC-Redist-LinuxX64.tar.gz" \
+    VRMF=9.2.0.0
+# Install the MQ client from the Redistributable package. This also contains the
+# header files we need to compile against. Setup the subset of the package
+# we are going to keep - the genmqpkg.sh script removes unneeded parts
+ENV genmqpkg_incnls=1 \
+    genmqpkg_incsdk=1 \
+    genmqpkg_inctls=1
+RUN cd /opt/mqm \
+    && curl -LO "$RDURL/$VRMF-$RDTAR" \
+    && tar -zxf ./*.tar.gz \
+    && rm -f ./*.tar.gz \
+    && bin/genmqpkg.sh -b /opt/mqm
+
+WORKDIR /go/src/app
+COPY go.mod .
+COPY cmd/ /go/src/app
+RUN go mod tidy
+RUN go build -o /go/bin/app
+
+
+# We use the `distroless/cc` because the `mq-golang` client depends on `libstdc++6` 
+FROM gcr.io/distroless/cc
+COPY --from=build-env /go/bin/app /
+COPY --from=build-env /opt/mqm /opt/mqm
+CMD ["/app"]

--- a/e2e/images/ibmmq/cmd/connection.go
+++ b/e2e/images/ibmmq/cmd/connection.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/ibm-messaging/mq-golang/v5/ibmmq"
+)
+
+type msgMode string
+
+const (
+	PUT msgMode = "PUT"
+	GET         = "GET"
+)
+
+type connectionConfig struct {
+	host         string
+	port         string
+	queueManager string
+	channel      string
+	queueName    string
+
+	appUsername string
+	appPassword string
+}
+
+func setConnectionConfigFromEnv(connCfg *connectionConfig) error {
+	lookupRequiredEnvKey := func(envKey string) (string, error) {
+		val, ok := os.LookupEnv(envKey)
+		if !ok {
+			return "", fmt.Errorf("missing value for the required environment variable '%s'", envKey)
+		}
+		return val, nil
+	}
+
+	host, err := lookupRequiredEnvKey("HOST")
+	if err != nil {
+		return err
+	}
+	connCfg.host = host
+
+	port, err := lookupRequiredEnvKey("PORT")
+	if err != nil {
+		return err
+	}
+	connCfg.port = port
+
+	queueManager, err := lookupRequiredEnvKey("QUEUE_MANAGER")
+	if err != nil {
+		return err
+	}
+	connCfg.queueManager = queueManager
+
+	channel, err := lookupRequiredEnvKey("CHANNEL")
+	if err != nil {
+		return err
+	}
+	connCfg.channel = channel
+
+	queueName, err := lookupRequiredEnvKey("QUEUE_NAME")
+	if err != nil {
+		return err
+	}
+	connCfg.queueName = queueName
+
+	connCfg.appUsername = os.Getenv("APP_USERNAME")
+	connCfg.appPassword = os.Getenv("APP_PASSWORD")
+
+	return nil
+}
+
+func createConnection(connCfg connectionConfig) (ibmmq.MQQueueManager, error) {
+	log.Println("setting up connection to MQ")
+	// Allocate the default MQ Connection Options (MQCNO) structure needed for the CONNX call.
+	conn := ibmmq.NewMQCNO()
+
+	if connCfg.appUsername != "" {
+		log.Printf("username '%s' has been specified\n", connCfg.appUsername)
+		// The MQ Security Parameters (MQCSP)
+		csp := ibmmq.NewMQCSP()
+		csp.AuthenticationType = ibmmq.MQCSP_AUTH_USER_ID_AND_PWD
+		csp.UserId = connCfg.appUsername
+		csp.Password = connCfg.appPassword
+
+		conn.SecurityParms = csp
+	}
+
+	// Allocate the default MQ Channel Definition (MQCD) with the required fields
+	cd := ibmmq.NewMQCD()
+	cd.ChannelName = connCfg.channel
+	cd.ConnectionName = connCfg.host + "(" + connCfg.port + ")"
+	log.Printf("connecting to %s\n", cd.ConnectionName)
+
+	conn.ClientConn = cd
+	conn.Options = ibmmq.MQCNO_CLIENT_BINDING
+	log.Printf("attempting connection to queue manager(QMGR): %s\n", connCfg.queueManager)
+
+	return ibmmq.Connx(connCfg.queueManager, conn)
+}
+
+func openQueue(qMgrObject ibmmq.MQQueueManager, queueName string, mode msgMode) (ibmmq.MQObject, error) {
+	var (
+		qObject ibmmq.MQObject
+		err     error
+	)
+
+	mqod := ibmmq.NewMQOD()
+	openOptions := ibmmq.MQOO_OUTPUT
+
+	switch mode {
+	case PUT:
+		mqod.ObjectType = ibmmq.MQOT_Q
+		mqod.ObjectName = queueName
+
+	case GET:
+		openOptions = ibmmq.MQOO_INPUT_SHARED
+		mqod.ObjectType = ibmmq.MQOT_Q
+		mqod.ObjectName = queueName
+
+	default:
+		return qObject, fmt.Errorf("invalid msgMode, it must be either 'PUT' or 'GET'")
+	}
+
+	qObject, err = qMgrObject.Open(mqod, openOptions)
+
+	return qObject, err
+}

--- a/e2e/images/ibmmq/cmd/main.go
+++ b/e2e/images/ibmmq/cmd/main.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/ibm-messaging/mq-golang/v5/ibmmq"
+)
+
+func main() {
+	var connCfg connectionConfig
+	if err := setConnectionConfigFromEnv(&connCfg); err != nil {
+		log.Fatal(err)
+	}
+
+	qMgr, err := createConnection(connCfg)
+	if err != nil {
+		log.Fatal("unable to establish connection to the queue manager(QMGR): ", err)
+	}
+	defer func() {
+		if err := qMgr.Disc(); err != nil {
+			log.Println("error while disconnecting from the queue manager(QMGR): ", err)
+		}
+	}()
+
+	mode := ""
+	if len(os.Args) > 1 {
+		mode = os.Args[1]
+	}
+	switch mode {
+	case "producer":
+		if err := produceMessages(qMgr, connCfg.queueName); err != nil {
+			log.Fatal(err)
+		}
+	case "consumer":
+		if err := consumeMessages(qMgr, connCfg.queueName); err != nil {
+			log.Fatal(err)
+		}
+	default:
+		log.Fatalf("invalid mode '%s', it must be either 'producer' or 'consumer'\n", mode)
+	}
+}
+
+const (
+	defaultProducerConsumerSleepTime = 1
+	defaultProducedNumMessages       = 100
+)
+
+type message struct {
+	Content string `json:"content"`
+	Number  int    `json:"number"`
+}
+
+func consumeMessages(qMgr ibmmq.MQQueueManager, queueName string) error {
+	var err error
+
+	qObject, err := openQueue(qMgr, queueName, GET)
+	if err != nil {
+		return fmt.Errorf("failed to open the queue %s: %w", queueName, err)
+	}
+	defer func() {
+		if cerr := qObject.Close(0); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	// Sleep to demonstrate scaling
+	sleepTimeString := os.Getenv("CONSUMER_SLEEP_TIME")
+	sleepTime, err := strconv.Atoi(sleepTimeString)
+	if err != nil {
+		sleepTime = defaultProducerConsumerSleepTime
+	}
+
+	for {
+		// The Get requires control structures, the Message Descriptor (MQMD)
+		// and Get Options (MQGMO). We create those with default values.
+		getmqmd := ibmmq.NewMQMD()
+		gmo := ibmmq.NewMQGMO()
+		// The default options are OK, but it's always a good idea to be explicit
+		// about transactional boundaries as not all platforms behave the same way.
+		gmo.Options = ibmmq.MQGMO_NO_SYNCPOINT
+		// Set options to wait for a maximum of 3 seconds for any new message to arrive
+		gmo.Options |= ibmmq.MQGMO_WAIT
+		// Unlimited get
+		gmo.WaitInterval = ibmmq.MQWI_UNLIMITED
+
+		buf := make([]byte, 1024)
+		datalen, err := qObject.Get(getmqmd, gmo, buf)
+		if err != nil {
+			mqret := err.(*ibmmq.MQReturn)
+			if mqret.MQRC == ibmmq.MQRC_NO_MSG_AVAILABLE {
+				log.Println("no messages are currently available to consume, this will stop the consumer loop")
+				// No message is available is an expected situation, and so we don't handle it as a real error.
+				err = nil
+			}
+			break
+		}
+
+		var msg message
+		err = json.Unmarshal(buf[:datalen], &msg)
+		if err != nil {
+			return fmt.Errorf("failed to parse JSON message: %w", err)
+		}
+		log.Printf("received message from %s with content: %s, number: %d\n", queueName, msg.Content, msg.Number)
+
+		time.Sleep(time.Duration(sleepTime) * time.Second)
+	}
+
+	return err
+}
+
+func produceMessages(qMgr ibmmq.MQQueueManager, queueName string) error {
+	var err error
+
+	qObject, err := openQueue(qMgr, queueName, PUT)
+	if err != nil {
+		return fmt.Errorf("failed to open the queue %s: %w", queueName, err)
+	}
+	defer func() {
+		if cerr := qObject.Close(0); cerr != nil && err == nil {
+			err = cerr
+		}
+	}()
+
+	// Sleep to demonstrate scaling
+	sleepTimeString := os.Getenv("PRODUCER_SLEEP_TIME")
+	sleepTime, err := strconv.Atoi(sleepTimeString)
+	if err != nil {
+		sleepTime = defaultProducerConsumerSleepTime
+	}
+
+	numMessages, err := strconv.Atoi(os.Getenv("NUM_MESSAGES"))
+	if err != nil {
+		numMessages = defaultProducedNumMessages
+	}
+
+	for i := 0; i < numMessages; i++ {
+		// The PUT requires control structures, the Message Descriptor (MQMD)
+		// and Put Options (MQPMO). Create those with default values.
+		putmqmd := ibmmq.NewMQMD()
+		pmo := ibmmq.NewMQPMO()
+		// The default options are OK, but it's always
+		// a good idea to be explicit about transactional boundaries as
+		// not all platforms behave the same way.
+		pmo.Options = ibmmq.MQPMO_NO_SYNCPOINT
+		// Tell MQ what the message body format is. In this case, a text string
+		putmqmd.Format = ibmmq.MQFMT_STRING
+
+		msg := &message{
+			Content: "Msg created at " + time.Now().Format(time.RFC3339),
+			Number:  i + 1,
+		}
+		buf, err := json.Marshal(msg)
+		if err != nil {
+			return fmt.Errorf("error marshalling the message data to send: %w", err)
+		}
+
+		err = qObject.Put(putmqmd, pmo, buf)
+		if err != nil {
+			return fmt.Errorf("failed to send message: %w", err)
+		}
+		log.Printf("message: %s sent to %s\n", buf, strings.TrimSpace(qObject.Name))
+
+		time.Sleep(time.Duration(sleepTime) * time.Second)
+	}
+
+	return err
+}

--- a/e2e/images/ibmmq/go.mod
+++ b/e2e/images/ibmmq/go.mod
@@ -1,0 +1,5 @@
+module github.com/kedacore/test-tools
+
+go 1.22.2
+
+require github.com/ibm-messaging/mq-golang/v5 v5.5.4

--- a/e2e/images/ibmmq/go.sum
+++ b/e2e/images/ibmmq/go.sum
@@ -1,0 +1,2 @@
+github.com/ibm-messaging/mq-golang/v5 v5.5.4 h1:K7AI4d76h5htmcT5uiWRxFxoOsVTtZH07BlVlwJIiIE=
+github.com/ibm-messaging/mq-golang/v5 v5.5.4/go.mod h1:xCV0vl1+ik3VyWZnwAj++2J89vSTzhXP1gXhG0X3IYE=


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

This is the e2e image in preparation for the ibm-mq scaler e2e test  https://github.com/kedacore/keda/issues/1287

The image will help to create the producer/consumer resources inside the k8s cluster. 

### Demo
After building the docker image:
- producer:

```shell
$ docker run --network=host \
    --env APP_USERNAME="app" \
    --env APP_PASSWORD="my-app-password" \
    --env QUEUE_MANAGER="ibmmqnonativeha" \
    --env QUEUE_NAME="DEV.QUEUE.2" \
    --env HOST="192.168.49.2" \
    --env PORT="31335" \
    --env NUM_MESSAGES="10" \
    --env CHANNEL="DEV.APP.SVRCONN" \
    --env PRODUCER_SLEEP_TIME="1" \
    ibm-mq-cli /app producer
```

```
2024/05/12 12:39:18 setting up connection to MQ
2024/05/12 12:39:18 username 'app' has been specified
2024/05/12 12:39:18 connecting to 192.168.49.2(31335)
2024/05/12 12:39:18 attempting connection to queue manager(QMGR): ibmmqnonativeha
2024/05/12 12:39:18 message: {"content":"Msg created at 2024-05-12T12:39:18Z","number":1} sent to DEV.QUEUE.2
2024/05/12 12:39:19 message: {"content":"Msg created at 2024-05-12T12:39:19Z","number":2} sent to DEV.QUEUE.2
2024/05/12 12:39:20 message: {"content":"Msg created at 2024-05-12T12:39:20Z","number":3} sent to DEV.QUEUE.2
2024/05/12 12:39:21 message: {"content":"Msg created at 2024-05-12T12:39:21Z","number":4} sent to DEV.QUEUE.2
2024/05/12 12:39:22 message: {"content":"Msg created at 2024-05-12T12:39:22Z","number":5} sent to DEV.QUEUE.2
2024/05/12 12:39:23 message: {"content":"Msg created at 2024-05-12T12:39:23Z","number":6} sent to DEV.QUEUE.2
2024/05/12 12:39:24 message: {"content":"Msg created at 2024-05-12T12:39:24Z","number":7} sent to DEV.QUEUE.2
2024/05/12 12:39:25 message: {"content":"Msg created at 2024-05-12T12:39:25Z","number":8} sent to DEV.QUEUE.2
2024/05/12 12:39:26 message: {"content":"Msg created at 2024-05-12T12:39:26Z","number":9} sent to DEV.QUEUE.2
2024/05/12 12:39:27 message: {"content":"Msg created at 2024-05-12T12:39:27Z","number":10} sent to DEV.QUEUE.2
```

- consumer:

```shell
$ docker run --network=host \
    --env APP_USERNAME="app" \
    --env APP_PASSWORD="my-app-password" \
    --env QUEUE_MANAGER="ibmmqnonativeha" \
    --env HOST="192.168.49.2" \
    --env PORT="31335" \
    --env QUEUE_NAME="DEV.QUEUE.2" \
    --env CHANNEL="DEV.APP.SVRCONN" \
    ibm-mq-cli /app consumer
```

```
2024/05/12 12:39:31 setting up connection to MQ
2024/05/12 12:39:31 username 'app' has been specified
2024/05/12 12:39:31 connecting to 192.168.49.2(31335)
2024/05/12 12:39:31 attempting connection to queue manager(QMGR): ibmmqnonativeha
2024/05/12 12:39:31 received message from DEV.QUEUE.2 with content: Msg created at 2024-05-12T12:39:18Z, number: 1
2024/05/12 12:39:32 received message from DEV.QUEUE.2 with content: Msg created at 2024-05-12T12:39:19Z, number: 2
2024/05/12 12:39:33 received message from DEV.QUEUE.2 with content: Msg created at 2024-05-12T12:39:20Z, number: 3
2024/05/12 12:39:34 received message from DEV.QUEUE.2 with content: Msg created at 2024-05-12T12:39:21Z, number: 4
2024/05/12 12:39:35 received message from DEV.QUEUE.2 with content: Msg created at 2024-05-12T12:39:22Z, number: 5
2024/05/12 12:39:36 received message from DEV.QUEUE.2 with content: Msg created at 2024-05-12T12:39:23Z, number: 6
2024/05/12 12:39:37 received message from DEV.QUEUE.2 with content: Msg created at 2024-05-12T12:39:24Z, number: 7
2024/05/12 12:39:38 received message from DEV.QUEUE.2 with content: Msg created at 2024-05-12T12:39:25Z, number: 8
2024/05/12 12:39:39 received message from DEV.QUEUE.2 with content: Msg created at 2024-05-12T12:39:26Z, number: 9
2024/05/12 12:39:40 received message from DEV.QUEUE.2 with content: Msg created at 2024-05-12T12:39:27Z, number: 10
```

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
