### PR TITLE
trivy db image sync job

### DIFF
--- a/.github/workflows/trivy-sync-job.yaml
+++ b/.github/workflows/trivy-sync-job.yaml
@@ -1,0 +1,29 @@
+name: Periodic trivy db copy job
+
+# Run every hour
+on:
+  schedule:
+    - cron: '0 * * * *'  # Runs every hour at the top of the hour
+
+jobs:
+  copy-oci-trivy-db-image:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write    # for GHCR write access
+
+    steps:
+      # Set up ORAS cli
+      - uses: oras-project/setup-oras@v1
+
+      # Authenticate to the source and target registries (GitHub Container Registry)
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Copy the OCI image from Aqua Security to Kedacore
+      - name: Copy OCI image using ORAS
+        run: |
+          oras cp ghcr.io/aquasecurity/trivy-db:2 ghcr.io/kedacore/trivy-db:2


### PR DESCRIPTION
the trivy-db image has been under a lot of stress recently, frequently hitting rate limiting. This resulted in failures in CI for kedacore/keda repository PR checks. The https://github.com/kedacore/keda/pull/6243 swapped the trivy image repository with a cached version under kedacore ghcr registry. This PR adds a best effort hourly sync for the db image so scans are up to date.