### PR TITLE
fix: Use individual ACK policy for artemismq image

### DIFF
--- a/e2e/images/artemis/cmd/main.go
+++ b/e2e/images/artemis/cmd/main.go
@@ -73,7 +73,7 @@ func consumeMessages() {
 		panic(err)
 	}
 	defer conn.Disconnect()
-	sub, err := conn.Subscribe(destination, stomp.AckAuto, stomp.SubscribeOpt.Header("subscription-type", "ANYCAST"))
+	sub, err := conn.Subscribe(destination, stomp.AckClientIndividual, stomp.SubscribeOpt.Header("subscription-type", "ANYCAST"))
 	if err != nil {
 		panic(fmt.Errorf("could not subscribe to queue %s: %v", destination, err))
 	}
@@ -87,6 +87,7 @@ func consumeMessages() {
 			panic(fmt.Errorf("failed to decode message: %v: %v", msg.Header, err))
 		}
 		log.Println(*m)
+		conn.Ack(msg)
 		time.Sleep(time.Duration(sleep * int(time.Millisecond)))
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)

Fixes #
