### PR TITLE
fix: Build k6 images only on supported platforms

### DIFF
--- a/.github/workflows/keda-k6-runner.yaml
+++ b/.github/workflows/keda-k6-runner.yaml
@@ -35,3 +35,5 @@ jobs:
 
       - name: Build and publish Tools image
         run: make push-keda-k6-runner
+        env:
+          BUILD_PLATFORMS: linux/amd64,linux/arm64


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [ ] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Fixes #
