### PR TITLE
Allow for continuous publishing of messages to RabbitMQ test queue in selected intervals

### DIFF
--- a/e2e/images/rabbitmq/cmd/send/send.go
+++ b/e2e/images/rabbitmq/cmd/send/send.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/streadway/amqp"
 )
@@ -17,42 +18,64 @@ func failOnError(err error, msg string) {
 
 func main() {
 	url := os.Args[1]
-	messageCount, err := strconv.Atoi(os.Args[2])
 	queueName := "hello"
-	if len(os.Args) == 4 {
+	interval := 0
+
+	messageCount, err := strconv.Atoi(os.Args[2])
+	failOnError(err, "Failed to parse second arg as messageCount : int")
+
+	if len(os.Args) >= 4 {
 		queueName = os.Args[3]
 	}
-	failOnError(err, "Failed to parse second arg as messageCount : int")
+
+	if len(os.Args) == 5 {
+		interval, err = strconv.Atoi(os.Args[4])
+	}
+	failOnError(err, "Failed to parse fourth arg as messages publishing interval (in seconds) : int")
+
 	conn, err := amqp.Dial(url)
 	failOnError(err, "Failed to connect to RabbitMQ")
 	defer conn.Close()
 
 	ch, err := conn.Channel()
 	failOnError(err, "Failed to open a channel")
+
 	defer ch.Close()
 
 	q, err := ch.QueueDeclare(
-		queueName, 	// name
-		false,   	// durable
-		false,   	// delete when unused
-		false,   	// exclusive
-		false,   	// no-wait
-		nil,     	// arguments
+		queueName, // name
+		false,     // durable
+		false,     // delete when unused
+		false,     // exclusive
+		false,     // no-wait
+		nil,       // arguments
 	)
 	failOnError(err, "Failed to declare a queue")
 
-	for i := 0; i < messageCount; i++ {
-		body := fmt.Sprintf("Hello World: %d", i)
-		err = ch.Publish(
-			"",     // exchange
-			q.Name, // routing key
-			false,  // mandatory
-			false,  // immediate
-			amqp.Publishing{
-				ContentType: "text/plain",
-				Body:        []byte(body),
-			})
-		log.Printf(" [x] Sent %s", body)
-		failOnError(err, "Failed to publish a message")
+	if interval > 0 {
+		log.Printf(" [*] Publishing %d message(s) per %d second(s). To exit press CTRL+C", messageCount, interval)
+	}
+
+	for {
+		for i := 0; i < messageCount; i++ {
+			body := fmt.Sprintf("Hello World: %d", i)
+			err = ch.Publish(
+				"",     // exchange
+				q.Name, // routing key
+				false,  // mandatory
+				false,  // immediate
+				amqp.Publishing{
+					ContentType: "text/plain",
+					Body:        []byte(body),
+				})
+			log.Printf(" [x] Sent %s", body)
+			failOnError(err, "Failed to publish a message")
+		}
+
+		if interval == 0 {
+			break
+		}
+
+		time.Sleep(time.Duration(interval) * time.Second)
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

By default `send` command ends its job after sending specified number of messages on to the RabbitMQ test queue. This change allows to repeatedly send number of messages in given interval (in seconds), allowing to simulate constant messages publication. It is necessary for E2E tests that validate `DeliverGetRate`, `PublishedToDeliveredRatio` and `ExpectedQueueConsumptionTime` trigger modes in RabbitMQ scaler.

To use this feature, complete list of arguments must be provided to `send` command, where the fourth one represents interval value. No value for interval implies default operation model (send and quit).

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [x] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

References:
- https://github.com/kedacore/keda/pull/6933
- https://github.com/kedacore/keda-docs/pull/1601