### PR TITLE
build and push e2e images as multiarch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,5 +29,11 @@ jobs:
           DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
         run: echo $DOCKER_HUB_ACCESS_TOKEN | docker login -u $DOCKER_HUB_USERNAME --password-stdin
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: e2e-images
         run: make e2e-images

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build-e2e-images:
 	IMAGE_TAG=$(IMAGE_TAG) ./e2e/images/build.sh
 
 push-e2e-images:
-	IMAGE_TAG=$(IMAGE_TAG) ./e2e/images/build.sh --push
+	IMAGE_TAG=$(IMAGE_TAG) ./e2e/images/build.sh --push --platform ${BUILD_PLATFORMS}
 
 ##################################################
 # tools image                                    #

--- a/e2e/images/apache-ab/Dockerfile
+++ b/e2e/images/apache-ab/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM --platform=${BUILDPLATFORM} alpine
 
 ENV TERM linux
 RUN apk --no-cache add apache2-utils

--- a/e2e/images/build.sh
+++ b/e2e/images/build.sh
@@ -1,24 +1,48 @@
 #! /bin/bash
-set -e
+set -euo pipefail
+
+# not all images can be built as multiarch at the moment
+# here is a list of images that must be multiarch for e2e tests to pass
+declare -A build_as_multiarch=(
+    ["apache-ab"]=true
+    ["websockets"]=true
+)
 
 DIR=$(dirname "$0")
 
-if [ -z "$IMAGE_TAG" ]
-then
+if [[ -z "${IMAGE_TAG:-}" ]]; then
     IMAGE_TAG=latest
 fi
 
+options=$(getopt -l "push,platform:" -o "p,x:" -- "$@")
+eval set -- "$options"
+
+PUSH=false
+PLATFORM=""
+while true; do
+  case "$1" in
+    -p|--push) PUSH=true; shift ;;
+    -x|--platform) PLATFORM="$2"; shift 2 ;;
+    --) shift; break ;;
+    *) echo "Invalid option: $1" >&2; exit 1 ;;
+  esac
+done
+
 cd $DIR
 
-if [ "$1" == "--push" ]
-then
-    for IMAGE_NAME in $(find * -name Dockerfile -exec dirname {} \; | tr '/' '-')
-    do
-        docker image push -a ghcr.io/kedacore/tests-$IMAGE_NAME
+if [[ "$PUSH" == true ]]; then
+    for IMAGE in $(find * -name Dockerfile); do
+        IMAGE_NAME=$(dirname $IMAGE | tr '/' '-')
+        if [[ "$PLATFORM" != "" && "${build_as_multiarch[$IMAGE_NAME]:-false}" == true ]]; then
+            echo "building and pushing $IMAGE_NAME from $IMAGE for $PLATFORM"
+            docker buildx build --push --platform "$PLATFORM" -t "ghcr.io/kedacore/tests-$IMAGE_NAME" ./$IMAGE
+        else
+            echo "building and pushing $IMAGE_NAME"
+            docker image push -a ghcr.io/kedacore/tests-$IMAGE_NAME
+        fi
     done
 else
-    for IMAGE in $(find * -name Dockerfile)
-    do
+    for IMAGE in $(find * -name Dockerfile); do
         IMAGE_NAME=$(dirname $IMAGE | tr '/' '-')
         pushd $(dirname $IMAGE)
         docker build --label "org.opencontainers.image.source=https://github.com/kedacore/test-tools" -t ghcr.io/kedacore/tests-$IMAGE_NAME:$IMAGE_TAG -t ghcr.io/kedacore/tests-$IMAGE_NAME:latest .

--- a/e2e/images/websockets/Dockerfile
+++ b/e2e/images/websockets/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.12.0
+FROM --platform=${BUILDPLATFORM} node:22.12.0
 
 WORKDIR /usr/src/app
 

--- a/k6-runner/Dockerfile
+++ b/k6-runner/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM} golang:1.23-alpine3.19 as builder
+FROM --platform=${BUILDPLATFORM} golang:1.24-alpine3.22 AS builder
 WORKDIR $GOPATH/src/go.k6.io/k6
 RUN apk --no-cache add git
 
@@ -6,7 +6,8 @@ ARG TARGETOS
 ARG TARGETARCH
 ARG K6_VERSION
 RUN go install go.k6.io/xk6/cmd/xk6@latest
-RUN GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" xk6 build "${K6_VERSION}" \
+RUN GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" xk6 build \
+        --k6-version "${K6_VERSION}" \
         --output /tmp/k6 \
         --with github.com/grafana/xk6-kubernetes@latest \
         --with github.com/grafana/xk6-disruptor@latest \


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

e2e tests for http-add-on started to fail for ARM64 machines
* https://github.com/kedacore/http-add-on/actions/runs/17765971664/job/50489528022?pr=1298

The reason seems to be that we don't build certain images those tests need as multiarch
```
$ docker manifest inspect ghcr.io/kedacore/tests-apache-ab | jq '.mediaType'
"application/vnd.docker.distribution.manifest.v2+json"

$ docker manifest inspect ghcr.io/kedacore/tests-websockets:245a788 | jq '.mediaType'
"application/vnd.docker.distribution.manifest.v2+json"
```

How is it possible this worked in the past you ask? No clue, man...

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)