### PR TITLE
fix context path for buildx e2e image builds

### DIFF
--- a/e2e/images/build.sh
+++ b/e2e/images/build.sh
@@ -35,9 +35,10 @@ if [[ "$PUSH" == true ]]; then
         IMAGE_NAME=$(dirname $IMAGE | tr '/' '-')
         if [[ "$PLATFORM" != "" && "${build_as_multiarch[$IMAGE_NAME]:-false}" == true ]]; then
             echo "building and pushing $IMAGE_NAME from $IMAGE for $PLATFORM"
-            docker buildx build --push --platform "$PLATFORM" -t "ghcr.io/kedacore/tests-$IMAGE_NAME" ./$IMAGE
+            image_dir=$(dirname $IMAGE)
+            docker buildx build --push --platform "$PLATFORM" -t "ghcr.io/kedacore/tests-$IMAGE_NAME" ./$image_dir
         else
-            echo "building and pushing $IMAGE_NAME"
+            echo "only pushing $IMAGE_NAME"
             docker image push -a ghcr.io/kedacore/tests-$IMAGE_NAME
         fi
     done


### PR DESCRIPTION
<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

followup to https://github.com/kedacore/test-tools/pull/229, the path to docker context for buildx was wrong and included `./[path]/Dockerfile`. This PR changes that to only be `./[path]`

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
